### PR TITLE
Add function fixed for different size voxels and Gizmo prompt for placement assistance

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,6 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Workload.ManagedGame"
+  ]
+}

--- a/Assets/SimpleVoxelSystem/Objects/TestObject.asset
+++ b/Assets/SimpleVoxelSystem/Objects/TestObject.asset
@@ -88,6 +88,42 @@ MonoBehaviour:
   - position: {x: -0.0625, y: 0.0625, z: -0.0625}
     size: 0.125
     voxelData: 1793
+  - position: {x: -3.5, y: 0.5, z: 0.5}
+    size: 1
+    voxelData: 0
+  - position: {x: -3.5, y: 0.5, z: 1.5}
+    size: 1
+    voxelData: 0
+  - position: {x: -3.5, y: 1.5, z: 0.5}
+    size: 1
+    voxelData: 0
+  - position: {x: -3.5, y: 1.5, z: 1.5}
+    size: 1
+    voxelData: 0
+  - position: {x: -2.5, y: 1.5, z: 0.5}
+    size: 1
+    voxelData: 0
+  - position: {x: -2.5, y: 1.5, z: 1.5}
+    size: 1
+    voxelData: 0
+  - position: {x: -3.875, y: 1.625, z: 2.125}
+    size: 0.25
+    voxelData: 641
+  - position: {x: -3.875, y: 1.625, z: 2.375}
+    size: 0.25
+    voxelData: 641
+  - position: {x: -3.875, y: 1.875, z: 2.375}
+    size: 0.25
+    voxelData: 705
+  - position: {x: -3.625, y: 1.625, z: 2.125}
+    size: 0.25
+    voxelData: 641
+  - position: {x: -3.625, y: 1.625, z: 2.375}
+    size: 0.25
+    voxelData: 641
+  - position: {x: -3.625, y: 1.875, z: 2.375}
+    size: 0.25
+    voxelData: 705
   - position: {x: 0.5, y: -0.5, z: -3.5}
     size: 1
     voxelData: 0

--- a/Assets/SimpleVoxelSystem/Objects/TestObject.asset
+++ b/Assets/SimpleVoxelSystem/Objects/TestObject.asset
@@ -85,9 +85,36 @@ MonoBehaviour:
   - position: {x: -0.5, y: -0.5, z: 1.5}
     size: 1
     voxelData: 0
+  - position: {x: -3.75, y: 0.75, z: -0.25}
+    size: 0.5
+    voxelData: 257
+  - position: {x: -3.25, y: 0.75, z: -0.25}
+    size: 0.5
+    voxelData: 257
+  - position: {x: -3.75, y: 1.75, z: -0.25}
+    size: 0.5
+    voxelData: 257
+  - position: {x: -3.25, y: 1.75, z: -0.25}
+    size: 0.5
+    voxelData: 257
+  - position: {x: -2.75, y: 1.75, z: -0.25}
+    size: 0.5
+    voxelData: 257
+  - position: {x: -2.25, y: 1.75, z: -0.25}
+    size: 0.5
+    voxelData: 257
+  - position: {x: -1.75, y: 1.75, z: -0.25}
+    size: 0.5
+    voxelData: 257
   - position: {x: -0.0625, y: 0.0625, z: -0.0625}
     size: 0.125
     voxelData: 1793
+  - position: {x: -1.625, y: 2.125, z: -0.375}
+    size: 0.25
+    voxelData: 513
+  - position: {x: -1.625, y: 2.375, z: -0.375}
+    size: 0.25
+    voxelData: 513
   - position: {x: -3.5, y: 0.5, z: 0.5}
     size: 1
     voxelData: 0
@@ -124,6 +151,18 @@ MonoBehaviour:
   - position: {x: -3.625, y: 1.875, z: 2.375}
     size: 0.25
     voxelData: 705
+  - position: {x: -1.75, y: 1.25, z: 0.25}
+    size: 0.5
+    voxelData: 257
+  - position: {x: -1.75, y: 1.75, z: 0.25}
+    size: 0.5
+    voxelData: 257
+  - position: {x: -1.75, y: 1.25, z: 1.75}
+    size: 0.5
+    voxelData: 257
+  - position: {x: -1.75, y: 1.75, z: 1.75}
+    size: 0.5
+    voxelData: 257
   - position: {x: 0.5, y: -0.5, z: -3.5}
     size: 1
     voxelData: 0

--- a/Assets/SimpleVoxelSystem/Scenes/SimpleVoxels.unity
+++ b/Assets/SimpleVoxelSystem/Scenes/SimpleVoxels.unity
@@ -280,8 +280,8 @@ MonoBehaviour:
   sceneLight: {fileID: 535515810}
   Dynamic: 0
   IsPlaying: 0
-  debugPosVec3: {x: -3.625, y: -0.375, z: 2.125}
-  debugPos2Vec3: {x: -3.745183, y: -0.3688135, z: 2}
+  debugPosVec3: {x: 1.625, y: 0.125, z: 1.625}
+  debugPos2Vec3: {x: 1.5294821, y: 0, z: 1.6853209}
   debugSize: -1
 --- !u!23 &744558718
 MeshRenderer:

--- a/Assets/SimpleVoxelSystem/Scenes/SimpleVoxels.unity
+++ b/Assets/SimpleVoxelSystem/Scenes/SimpleVoxels.unity
@@ -280,6 +280,9 @@ MonoBehaviour:
   sceneLight: {fileID: 535515810}
   Dynamic: 0
   IsPlaying: 0
+  debugPosVec3: {x: -3.625, y: -0.375, z: 2.125}
+  debugPos2Vec3: {x: -3.745183, y: -0.3688135, z: 2}
+  debugSize: -1
 --- !u!23 &744558718
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -499,7 +502,7 @@ Camera:
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 1
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 1}
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0


### PR DESCRIPTION
FIX: Updated Add function to work at multiple size differences.
NEW: created Box Gizmo where Add would place next Voxel.

I've left code close to where it came from for quick reference, but there was an issue where Add was missing the mark on placing smaller Voxels against existing Voxels. The calculation is in new function getOffsetToNewCentreClosest, and the gizmo uses 2 new public Vec3, one new Int values labelled like debugPosVec3 and debugSize for initial use.

Future: It would be worth adding colour to the gizmo to show the placing colour, and there is potential for gizmos showing Remove/Replace cues on mouse movement as well. I'd also like to use left click for Add and right click for Remove as a quick Edit mode, but that would change the GUI panel significantly so I haven't touched yet.